### PR TITLE
MOM-23958 Addition of new paramters in collectd

### DIFF
--- a/xml_definition/collectd.conf.all
+++ b/xml_definition/collectd.conf.all
@@ -155,6 +155,20 @@ LoadPlugin lustre
 		##        "samedir_rename" times on the MDT
 		Type "md_stats_samedir_rename"
 	</Item>
+        <Item>
+                ## "parallel_rename_file" samples on MDT
+                ## Entry: md_stats
+                ## Field: derive-rename
+                ##        "parallel_rename_file" times on the MDT
+                Type "md_stats_parallel_rename_file"
+        </Item>
+        <Item>
+                ## "parallel_rename_dir" samples on MDT
+                ## Entry: md_stats
+                ## Field: derive-rename
+                ##        "parallel_rename_dir" times on the MDT
+                Type "md_stats_parallel_rename_dir"
+        </Item>
 	<Item>
 		## "crossdir_rename" samples on MDT
 		## Entry: md_stats

--- a/xml_definition/lustre-b_es6_0.m4
+++ b/xml_definition/lustre-b_es6_0.m4
@@ -481,6 +481,8 @@ HEAD(Lustre-es6_0)
   statfs: +\{ samples: +([[:digit:]]+), unit: usecs, min: *([[:digit:]]+), max: *([[:digit:]]+), sum: *([[:digit:]]+), sumsq: *([[:digit:]]+) }
   sync: +\{ samples: +([[:digit:]]+), unit: usecs, min: *([[:digit:]]+), max: *([[:digit:]]+), sum: *([[:digit:]]+), sumsq: *([[:digit:]]+) }
   samedir_rename: +\{ samples: +([[:digit:]]+), unit: usecs, min: *([[:digit:]]+), max: *([[:digit:]]+), sum: *([[:digit:]]+), sumsq: *([[:digit:]]+) }
+  parallel_rename_file: +\{ samples: +([[:digit:]]+), unit: usecs, min: *([[:digit:]]+), max: *([[:digit:]]+), sum: *([[:digit:]]+), sumsq: *([[:digit:]]+) }
+  parallel_rename_dir: +\{ samples: +([[:digit:]]+), unit: usecs, min: *([[:digit:]]+), max: *([[:digit:]]+), sum: *([[:digit:]]+), sumsq: *([[:digit:]]+) }
   crossdir_rename: +\{ samples: +([[:digit:]]+), unit: usecs, min: *([[:digit:]]+), max: *([[:digit:]]+), sum: *([[:digit:]]+), sumsq: *([[:digit:]]+) }</pattern>
 						JOBSTAT_FIELD(6, 1, job_id, string, derive, mdt, jobid, 1)
 						JOBSTAT_FIELD_META_OPERATIONS(6, 2, open, number, derive, mdt, 1)
@@ -498,7 +500,9 @@ HEAD(Lustre-es6_0)
 						JOBSTAT_FIELD_META_OPERATIONS(6, 62, statfs, number, derive, mdt, 1)
 						JOBSTAT_FIELD_META_OPERATIONS(6, 67, sync, number, derive, mdt, 1)
 						JOBSTAT_FIELD_META_OPERATIONS(6, 72, samedir_rename, number, derive, mdt, 1)
-						JOBSTAT_FIELD_META_OPERATIONS(6, 77, crossdir_rename, number, derive, mdt, 1)
+                                                JOBSTAT_FIELD_META_OPERATIONS(6, 77, parallel_rename_file, number, derive, mdt, 1)
+                                                JOBSTAT_FIELD_META_OPERATIONS(6, 82, parallel_rename_dir, number, derive, mdt, 1)
+                                                JOBSTAT_FIELD_META_OPERATIONS(6, 87, crossdir_rename, number, derive, mdt, 1)
 					</item>
 				</entry>
 			</entry>


### PR DESCRIPTION
Issue: Two new parameters are added in Lustre parallel_rename_dir and parallel_rename_file. Support for them is not present in collectd.

Fix: Added Lustre stat changes in collectd